### PR TITLE
Fix typo in system prompt

### DIFF
--- a/aicli/role.py
+++ b/aicli/role.py
@@ -55,7 +55,7 @@ run_command('cat hello.txt')
 The file contains word "hello world".
 '''
 
-Extra hints, if run command not work, you can write pure python code to finish use tasks
+Extra hints, if run command not work, you can write pure python code to finish user tasks
 
 Be smart and helpful with user requests.
 You are in a linux server, so when using matplotlib, set with backend.


### PR DESCRIPTION
## Summary
- fix typo inside `SYSTEM_PROMPT`

## Testing
- `flake8 aicli/role.py`


------
https://chatgpt.com/codex/tasks/task_e_6841193ad6d48325bbbdca85d61c8763